### PR TITLE
Fix typo on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Verecl Bash Runtime (`vercel-bash`)
+# Vercel Bash Runtime (`vercel-bash`)
 
 The Bash Builder takes an entrypoint of a Bash function, imports its
 dependencies, and bundles them into a Lambda.


### PR DESCRIPTION
Just a small fix, Vercel had a typo on the title.